### PR TITLE
Abort upload to pypi if pypy and cpy wheel versions don't match

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ script:
                        sort -u))
   - if [[ ${#wheel_versions[@]} -gt 1 ]]; then
       echo "Multiple wheel versions found (${wheel_versions[@]}). Aborting upload to pypi";
-      exit 1;
+      false;
     elif [[ ! $(python setup.py --version) =~ dev ]]; then
       echo "Not a dev version, uploading to pypi" &&
       twine upload dist/*.tar.gz wheelhouse/*.whl pypy-wheelhouse/*.whl;

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,9 @@ install:
   - pip install twine cibuildwheel
 
 script:
-  - cibuildwheel --output-dir wheelhouse
-  - sudo chown -R $USER .
-  - docker run --rm -w /app -v $PWD:/app
+  - docker run --user $(id -u):$(id -g) --rm -w /app -v $PWD:/app
     quay.io/wenxiang/kafka-cffi-pypy-builder scripts/build-wheels.sh
-  - sudo chown -R $USER .
+  - cibuildwheel --output-dir wheelhouse
   - python setup.py sdist
   - ls -la wheelhouse/*.whl pypy-wheelhouse/*.whl dist/*.tar.gz
   - wheel_versions=($(ls -1 wheelhouse/*.whl pypy-wheelhouse/*.whl |

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,18 @@ install:
 script:
   - cibuildwheel --output-dir wheelhouse
   - sudo chown -R $USER .
-  - docker run --rm -w /app -v $PWD:/app 
+  - docker run --rm -w /app -v $PWD:/app
     quay.io/wenxiang/kafka-cffi-pypy-builder scripts/build-wheels.sh
   - sudo chown -R $USER .
   - python setup.py sdist
   - ls -la wheelhouse/*.whl pypy-wheelhouse/*.whl dist/*.tar.gz
-  - if [[ ! $(python setup.py --version) =~ dev ]]; then
+  - wheel_versions=($(ls -1 wheelhouse/*.whl pypy-wheelhouse/*.whl |
+                       sed -re 's/.*kafka_cffi-([^-]+)-(pp|cp)[0-9]+.*/\1/' |
+                       sort -u))
+  - if [[ ${#wheel_versions[@]} -gt 1 ]]; then
+      echo "Multiple wheel versions found (${wheel_versions[@]}). Aborting upload to pypi";
+      exit 1;
+    elif [[ ! $(python setup.py --version) =~ dev ]]; then
       echo "Not a dev version, uploading to pypi" &&
       twine upload dist/*.tar.gz wheelhouse/*.whl pypy-wheelhouse/*.whl;
     else

--- a/scripts/build-wheels.sh
+++ b/scripts/build-wheels.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 for PYBIN in /opt/python/*/bin; do
+  echo "Checking git status before running bdist_wheel on $PYBIN/pypy"
+  git status
   $PYBIN/pypy setup.py bdist_wheel -d pypy-dist
 done
 


### PR DESCRIPTION
PyPy wheels have not been making it to PyPI because the wheel version is miscalculated to be `${version+1}.dev0+g${commit}.d${date}`. This indicates that the git tree is potentially dirty at that stage of the build, but I wasn't able to reproduce the issue.

In this PR, I've just made sure to abort the build if the detected PyPy wheel version does not match the CPython wheel version, so that we don't end up with half uploads in the future.

@wenxiang @ducpt85 