### PR TITLE
Fix librdkafka's ssl support in the manylinux wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,12 @@ matrix:
 install:
   - pip install twine cibuildwheel==0.12.0
 
+  # hack to get libffi-devel installed for cpython3.4. ideally this should be in
+  # install-libs.sh, but quay.io is broken right now.
+  - docker pull "$CIBW_MANYLINUX1_X86_64_IMAGE"
+  - docker run --name=kafka-cffi-manylinux-builder "$CIBW_MANYLINUX1_X86_64_IMAGE" yum install -y libffi-devel
+  - docker commit kafka-cffi-manylinux-builder "$CIBW_MANYLINUX1_X86_64_IMAGE"
+
 script:
   - docker run --rm -w /app -v $PWD:/app
     quay.io/wenxiang/kafka-cffi-pypy-builder scripts/build-wheels.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
   - pip install twine cibuildwheel
 
 script:
-  - docker run --user $(id -u):$(id -g) --rm -w /app -v $PWD:/app
+  - docker run --rm -w /app -v $PWD:/app
     quay.io/wenxiang/kafka-cffi-pypy-builder scripts/build-wheels.sh
   - cibuildwheel --output-dir wheelhouse
   - python setup.py sdist

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
         CIBW_MANYLINUX1_X86_64_IMAGE="quay.io/wenxiang/kafka-cffi-manylinux-builder"
 
 install:
-  - pip install twine cibuildwheel
+  - pip install twine cibuildwheel==0.12.0
 
 script:
   - docker run --rm -w /app -v $PWD:/app

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ script:
   - docker run --rm -w /app -v $PWD:/app
     quay.io/wenxiang/kafka-cffi-pypy-builder scripts/build-wheels.sh
   - cibuildwheel --output-dir wheelhouse
+  - sudo chown -R $(id -u):$(id -g) .
   - python setup.py sdist
   - ls -la wheelhouse/*.whl pypy-wheelhouse/*.whl dist/*.tar.gz
   - wheel_versions=($(ls -1 wheelhouse/*.whl pypy-wheelhouse/*.whl |

--- a/scripts/build-wheels.sh
+++ b/scripts/build-wheels.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64
+
 for PYBIN in /opt/python/*/bin; do
   echo "Checking git status before running bdist_wheel on $PYBIN/pypy"
   git status

--- a/scripts/build-wheels.sh
+++ b/scripts/build-wheels.sh
@@ -7,6 +7,5 @@ for PYBIN in /opt/python/*/bin; do
 done
 
 for whl in $(ls pypy-dist/*.whl); do
-  LD_LIBRARY_PATH=/usr/local/lib \
   /opt/python/pp360/bin/auditwheel repair -w pypy-wheelhouse $whl
 done

--- a/scripts/install-libs.sh
+++ b/scripts/install-libs.sh
@@ -11,14 +11,14 @@ if [[ ! -e /usr/local/lib/librdkafka.so ]]; then
   mkdir /tmp/openssl && cd $_ && \
     curl -L https://www.openssl.org/source/openssl-$OPENSSL_VER.tar.gz | \
     tar xz --strip-components=1 && \
-    ./config zlib no-krb5 zlib shared && \
-    make && make install && \
+    ./config --prefix=/usr/local zlib no-krb5 zlib shared && \
+    make && make install && ldconfig && \
     rm -rf /tmp/openssl
 
   mkdir /tmp/librdkafka && cd $_ && \
     curl -L https://github.com/edenhill/librdkafka/archive/v$LIBRDKAFKA_VERSION.tar.gz | \
     tar xz --strip-components=1 && \
-    ./configure && make && make install && \
+    ./configure && make && make install && ldconfig && \
     rm -rf /tmp/librdkafka
 else
   echo "librdkafka.so exists, skipping library install"

--- a/scripts/install-libs.sh
+++ b/scripts/install-libs.sh
@@ -8,6 +8,10 @@ if [[ ! -e /usr/local/lib/librdkafka.so ]]; then
 
   yum install -y zlib-devel unzip
 
+  for i in /usr/local/lib /usr/local/lib64; do
+    echo $i
+  done > /etc/ld.so.conf.d/usrlocal.conf
+
   mkdir /tmp/openssl && cd $_ && \
     curl -L https://www.openssl.org/source/openssl-$OPENSSL_VER.tar.gz | \
     tar xz --strip-components=1 && \


### PR DESCRIPTION
librdkafka was actually built without SSL support in the manylinux wheels because eventhough we compiled and installed OpenSSL, the default installation location is `/usr/local/ssl/{bin,lib,include}`, which librdkafka's configure script was unable to find.

```python
In [1]: from kafka_cffi import Producer
   ...: config = {'security.protocol': 'ssl'}
   ...: p = Producer(config)
   ...:
---------------------------------------------------------------------------
KafkaException                            Traceback (most recent call last)
<ipython-input-1-7c496ecfaf14> in <module>()
      1 from kafka_cffi import Producer
      2 config = {'security.protocol': 'ssl'}
----> 3 p = Producer(config)

/opt/lc3-env/site-packages/kafka_cffi/producer.pyc in __init__(self, *args, **kwargs)
     42         self.on_delivery = None
     43         self.dr_only_error = False
---> 44         super(Producer, self).__init__(*args, **kwargs)
     45
     46     def __len__(self):

/opt/lc3-env/site-packages/kafka_cffi/client.pyc in __init__(self, *args, **kwargs)
     74
     75         try:
---> 76             self.parse_conf()
     77             errstr = ffi.new("char[256]")
     78             self.rk = lib.rd_kafka_new(self.MODE, self.rd_conf, errstr, 256)

/opt/lc3-env/site-packages/kafka_cffi/producer.pyc in parse_conf(self)
     48
     49     def parse_conf(self):
---> 50         super(Producer, self).parse_conf()
     51
     52         on_delivery = self.conf_dict.get("on_delivery")

/opt/lc3-env/site-packages/kafka_cffi/client.pyc in parse_conf(self)
    186
    187             else:
--> 188                 self.populate_rd_conf(k, v)
    189
    190         lib.rd_kafka_conf_set_opaque(self.rd_conf, self.handle)

/opt/lc3-env/site-packages/kafka_cffi/client.pyc in populate_rd_conf(self, k, v)
    134                                   ensure_bytes(v), errstr, 256) != 0):
    135             raise KafkaException(KafkaError._INVALID_ARG,
--> 136                                  "%s: %s" % (k, ffi.string(errstr)))
    137
    138     def parse_conf(self):

KafkaException: (_INVALID_ARG: Local: Invalid argument or configuration, 'security.protocol: Invalid value for configuration property "security.protocol"')
```

This PR fixes the issue by specifying `--prefix=/usr/local`. Additionally, in order to work around an auditwheel bug (see https://github.com/wenxiang/kafka-cffi/commit/b5583dc5b4c782a5890dd372b96ea24ad23c8623), I've just resorted to building the wheel as the root user.